### PR TITLE
fix: add the context to calls to the go-buildkite client

### DIFF
--- a/buildkite_api.go
+++ b/buildkite_api.go
@@ -14,12 +14,12 @@ import (
 
 // JobStatusProvider defines the interface for getting job status
 type JobStatusProvider interface {
-	GetJobStatus(org, pipeline, build, job string) (*JobStatus, error)
+	GetJobStatus(ctx context.Context, org, pipeline, build, job string) (*JobStatus, error)
 }
 
 // LogProvider defines the interface for getting job logs
 type LogProvider interface {
-	GetJobLog(org, pipeline, build, job string) (io.ReadCloser, error)
+	GetJobLog(ctx context.Context, org, pipeline, build, job string) (io.ReadCloser, error)
 }
 
 // BuildkiteAPI combines both job status and log providers
@@ -65,10 +65,7 @@ func NewBuildkiteAPIExistingClient(client *buildkite.Client) *BuildkiteAPIClient
 // pipeline: pipeline slug
 // build: build number or UUID
 // job: job ID
-func (c *BuildkiteAPIClient) GetJobLog(org, pipeline, build, job string) (io.ReadCloser, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
+func (c *BuildkiteAPIClient) GetJobLog(ctx context.Context, org, pipeline, build, job string) (io.ReadCloser, error) {
 	jobLog, _, err := c.client.Jobs.GetJobLog(ctx, org, pipeline, build, job)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get job log: %w", err)
@@ -79,8 +76,8 @@ func (c *BuildkiteAPIClient) GetJobLog(org, pipeline, build, job string) (io.Rea
 }
 
 // GetJobStatus gets the current status of a job with retry logic
-func (c *BuildkiteAPIClient) GetJobStatus(org, pipeline, build, job string) (*JobStatus, error) {
-	return GetJobStatus(c.client, org, pipeline, build, job)
+func (c *BuildkiteAPIClient) GetJobStatus(ctx context.Context, org, pipeline, build, job string) (*JobStatus, error) {
+	return GetJobStatus(c.client, ctx, org, pipeline, build, job)
 }
 
 // ValidateAPIParams validates that all required API parameters are provided

--- a/buildkite_api_test.go
+++ b/buildkite_api_test.go
@@ -1,6 +1,7 @@
 package buildkitelogs
 
 import (
+	"context"
 	"testing"
 )
 
@@ -99,7 +100,7 @@ func TestValidateAPIParams(t *testing.T) {
 func TestGetJobLog_NoToken(t *testing.T) {
 	client := NewBuildkiteAPIClient("", "test")
 
-	_, err := client.GetJobLog("org", "pipeline", "build", "job")
+	_, err := client.GetJobLog(context.TODO(), "org", "pipeline", "build", "job")
 	if err == nil {
 		t.Error("Expected error when API token is empty")
 	}

--- a/client.go
+++ b/client.go
@@ -110,15 +110,14 @@ type Client struct {
 }
 
 // NewClient creates a new Client using the provided go-buildkite client
-func NewClient(client *buildkite.Client, storageURL string) (*Client, error) {
+func NewClient(ctx context.Context, client *buildkite.Client, storageURL string) (*Client, error) {
 	api := NewBuildkiteAPIExistingClient(client)
-	return NewClientWithAPI(api, storageURL)
+	return NewClientWithAPI(ctx, api, storageURL)
 }
 
 // NewClientWithAPI creates a new Client using a custom BuildkiteAPI implementation
-func NewClientWithAPI(api BuildkiteAPI, storageURL string) (*Client, error) {
+func NewClientWithAPI(ctx context.Context, api BuildkiteAPI, storageURL string) (*Client, error) {
 	// Initialize blob storage once during client creation
-	ctx := context.Background()
 	blobStorage, err := NewBlobStorage(ctx, storageURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize blob storage: %w", err)
@@ -211,7 +210,7 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, org, pipel
 
 	// Get job status to determine caching strategy
 	jobStatusStart := time.Now()
-	jobStatus, err := c.api.GetJobStatus(context.TODO(), org, pipeline, build, job)
+	jobStatus, err := c.api.GetJobStatus(ctx, org, pipeline, build, job)
 	jobStatusDuration := time.Since(jobStatusStart)
 
 	// Call after job status hooks
@@ -252,7 +251,7 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, org, pipel
 
 	// Download fresh logs from API
 	logDownloadStart := time.Now()
-	logReader, err := c.api.GetJobLog(context.TODO(), org, pipeline, build, job)
+	logReader, err := c.api.GetJobLog(ctx, org, pipeline, build, job)
 	logDownloadDuration := time.Since(logDownloadStart)
 
 	var logSize int64

--- a/client.go
+++ b/client.go
@@ -211,7 +211,7 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, org, pipel
 
 	// Get job status to determine caching strategy
 	jobStatusStart := time.Now()
-	jobStatus, err := c.api.GetJobStatus(org, pipeline, build, job)
+	jobStatus, err := c.api.GetJobStatus(context.TODO(), org, pipeline, build, job)
 	jobStatusDuration := time.Since(jobStatusStart)
 
 	// Call after job status hooks
@@ -252,7 +252,7 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, org, pipel
 
 	// Download fresh logs from API
 	logDownloadStart := time.Now()
-	logReader, err := c.api.GetJobLog(org, pipeline, build, job)
+	logReader, err := c.api.GetJobLog(context.TODO(), org, pipeline, build, job)
 	logDownloadDuration := time.Since(logDownloadStart)
 
 	var logSize int64

--- a/client_test.go
+++ b/client_test.go
@@ -17,11 +17,11 @@ type MockBuildkiteAPI struct {
 	jobStatus  *JobStatus
 }
 
-func (m *MockBuildkiteAPI) GetJobLog(org, pipeline, build, job string) (io.ReadCloser, error) {
+func (m *MockBuildkiteAPI) GetJobLog(ctx context.Context, org, pipeline, build, job string) (io.ReadCloser, error) {
 	return io.NopCloser(strings.NewReader(m.logContent)), nil
 }
 
-func (m *MockBuildkiteAPI) GetJobStatus(org, pipeline, build, job string) (*JobStatus, error) {
+func (m *MockBuildkiteAPI) GetJobStatus(ctx context.Context, org, pipeline, build, job string) (*JobStatus, error) {
 	return m.jobStatus, nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -38,7 +38,7 @@ func TestParquetClient_NewParquetClient(t *testing.T) {
 
 	storageURL := "file://" + tempDir
 
-	parquetClient, err := NewClient(client, storageURL)
+	parquetClient, err := NewClient(context.TODO(), client, storageURL)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestParquetClient_NewParquetClientWithAPI(t *testing.T) {
 
 	storageURL := "file://" + tempDir
 
-	parquetClient, err := NewClientWithAPI(mockAPI, storageURL)
+	parquetClient, err := NewClientWithAPI(context.TODO(), mockAPI, storageURL)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestParquetClient_DownloadAndCache(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	client, err := NewClientWithAPI(mockAPI, "file://"+tempDir)
+	client, err := NewClientWithAPI(context.TODO(), mockAPI, "file://"+tempDir)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestParquetClient_NewReader(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	client, err := NewClientWithAPI(mockAPI, "file://"+tempDir)
+	client, err := NewClientWithAPI(context.TODO(), mockAPI, "file://"+tempDir)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/cmd/bklog/parse_cli.go
+++ b/cmd/bklog/parse_cli.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -111,7 +112,7 @@ func runParse(config *Config) error {
 		}
 
 		client := buildkitelogs.NewBuildkiteAPIClient(apiToken, version)
-		logReader, err := client.GetJobLog(config.Organization, config.Pipeline, config.Build, config.Job)
+		logReader, err := client.GetJobLog(context.Background(), config.Organization, config.Pipeline, config.Build, config.Job)
 		if err != nil {
 			return fmt.Errorf("failed to fetch logs from API: %w", err)
 		}

--- a/cmd/bklog/parse_cli.go
+++ b/cmd/bklog/parse_cli.go
@@ -78,13 +78,15 @@ func handleParseCommand() {
 		}
 	}
 
-	if err := runParse(&config); err != nil {
+	ctx := context.Background()
+
+	if err := runParse(ctx, &config); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func runParse(config *Config) error {
+func runParse(ctx context.Context, config *Config) error {
 	var reader io.ReadCloser
 	var bytesProcessed int64
 
@@ -112,7 +114,7 @@ func runParse(config *Config) error {
 		}
 
 		client := buildkitelogs.NewBuildkiteAPIClient(apiToken, version)
-		logReader, err := client.GetJobLog(context.Background(), config.Organization, config.Pipeline, config.Build, config.Job)
+		logReader, err := client.GetJobLog(ctx, config.Organization, config.Pipeline, config.Build, config.Job)
 		if err != nil {
 			return fmt.Errorf("failed to fetch logs from API: %w", err)
 		}

--- a/examples/high-level-client/main.go
+++ b/examples/high-level-client/main.go
@@ -25,9 +25,11 @@ func main() {
 		log.Fatal("Failed to create buildkite client:", err)
 	}
 
+	ctx := context.Background()
+
 	// Create high-level Client
 	storageURL := "file://~/.bklog" // Uses default storage location
-	buildkiteLogsClient, err := buildkitelogs.NewClient(client, storageURL)
+	buildkiteLogsClient, err := buildkitelogs.NewClient(ctx, client, storageURL)
 	if err != nil {
 		log.Fatal("Failed to create buildkite logs client:", err)
 	}
@@ -65,7 +67,6 @@ func main() {
 			result.LocalPath, result.FileSize, result.Duration)
 	})
 
-	ctx := context.Background()
 	org := "myorg"
 	pipeline := "mypipeline"
 	build := "123"
@@ -114,7 +115,7 @@ func main() {
 	// Example 3: Using with custom API implementation
 	fmt.Println("\nExample with custom API:")
 	customAPI := &CustomBuildkiteAPI{} // Your custom implementation
-	customClient, err := buildkitelogs.NewClientWithAPI(customAPI, storageURL)
+	customClient, err := buildkitelogs.NewClientWithAPI(ctx, customAPI, storageURL)
 	if err != nil {
 		log.Printf("Failed to create custom client: %v", err)
 		return

--- a/examples/high-level-client/main.go
+++ b/examples/high-level-client/main.go
@@ -150,12 +150,12 @@ type CustomBuildkiteAPI struct {
 	// Your custom implementation fields
 }
 
-func (c *CustomBuildkiteAPI) GetJobLog(org, pipeline, build, job string) (io.ReadCloser, error) {
+func (c *CustomBuildkiteAPI) GetJobLog(ctx context.Context, org, pipeline, build, job string) (io.ReadCloser, error) {
 	// Your custom log fetching logic
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (c *CustomBuildkiteAPI) GetJobStatus(org, pipeline, build, job string) (*buildkitelogs.JobStatus, error) {
+func (c *CustomBuildkiteAPI) GetJobStatus(ctx context.Context, org, pipeline, build, job string) (*buildkitelogs.JobStatus, error) {
 	// Your custom job status logic
 	return nil, fmt.Errorf("not implemented")
 }

--- a/examples/smart-cache/main.go
+++ b/examples/smart-cache/main.go
@@ -50,14 +50,15 @@ func main() {
 	fmt.Println("- Permanent cache for terminal jobs")
 	fmt.Println("- Auto storage backend selection")
 
+	ctx := context.Background()
+
 	// Create high-level client
 	buildkiteAPIClient := buildkitelogs.NewBuildkiteAPIClient(apiToken, *version)
-	client, err := buildkitelogs.NewClientWithAPI(buildkiteAPIClient, "") // empty storageURL = auto-detect
+	client, err := buildkitelogs.NewClientWithAPI(ctx, buildkiteAPIClient, "") // empty storageURL = auto-detect
 	if err != nil {
 		log.Fatal("Failed to create client:", err)
 	}
 	defer client.Close()
-	ctx := context.Background()
 
 	start := time.Now()
 	cacheFile1, err := client.DownloadAndCache(
@@ -116,7 +117,7 @@ func main() {
 
 	// Create client with custom storage URL
 	var cacheFile4 string
-	s3Client, err := buildkitelogs.NewClientWithAPI(buildkiteAPIClient, s3URL)
+	s3Client, err := buildkitelogs.NewClientWithAPI(ctx, buildkiteAPIClient, s3URL)
 	if err != nil {
 		log.Printf("Failed to create S3 client: %v", err)
 		fmt.Println("   → Falling back to local storage for demo")
@@ -136,7 +137,7 @@ func main() {
 		fmt.Println("   → Falling back to local storage for demo")
 
 		// Fallback to local storage
-		localClient, err := buildkitelogs.NewClientWithAPI(buildkiteAPIClient, "file://./cache-demo")
+		localClient, err := buildkitelogs.NewClientWithAPI(ctx, buildkiteAPIClient, "file://./cache-demo")
 		if err != nil {
 			log.Printf("Failed to create local client: %v", err)
 		} else {
@@ -175,7 +176,7 @@ func main() {
 		fmt.Printf("  %d. TTL: %s\n", i+1, ttlDesc)
 
 		// Create client with separate cache directory for each TTL
-		ttlClient, err := buildkitelogs.NewClientWithAPI(buildkiteAPIClient, fmt.Sprintf("file://./cache-ttl-%d", i))
+		ttlClient, err := buildkitelogs.NewClientWithAPI(ctx, buildkiteAPIClient, fmt.Sprintf("file://./cache-ttl-%d", i))
 		if err != nil {
 			log.Printf("     Failed to create TTL client: %v", err)
 			continue

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.4
 require (
 	github.com/apache/arrow-go/v18 v18.4.0
 	github.com/buildkite/go-buildkite/v4 v4.5.1
-	github.com/cenkalti/backoff/v4 v4.3.0
 	gocloud.dev v0.43.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,6 @@ github.com/buildkite/go-buildkite/v4 v4.5.1 h1:45Vgtua5PlZwaaHiI0i7Zz9icOS8PTHkW
 github.com/buildkite/go-buildkite/v4 v4.5.1/go.mod h1:fMPu+/7hXzJ7Gy3HpGuVCLgeHqzDdrgHuwQvt8p370I=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 h1:aQ3y1lwWyqYPiWZThqv1aFbZMiM9vblcSArJRf2Irls=

--- a/job_status.go
+++ b/job_status.go
@@ -71,7 +71,7 @@ func IsTerminalState(state JobState) bool {
 }
 
 // GetJobStatus retrieves the current status of a Buildkite job with retry logic
-func GetJobStatus(client *buildkite.Client, org, pipeline, build, jobID string) (*JobStatus, error) {
+func GetJobStatus(client *buildkite.Client, ctx context.Context, org, pipeline, build, jobID string) (*JobStatus, error) {
 	var buildInfo buildkite.Build
 	var err error
 
@@ -82,9 +82,6 @@ func GetJobStatus(client *buildkite.Client, org, pipeline, build, jobID string) 
 	bo.MaxInterval = 10 * time.Second    // Max interval between retries
 
 	operation := func() error {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
 		buildInfo, _, err = client.Builds.Get(ctx, org, pipeline, build, nil)
 		if err != nil {
 			return fmt.Errorf("failed to get build info: %w", err)

--- a/job_status.go
+++ b/job_status.go
@@ -1,12 +1,7 @@
 package buildkitelogs
 
 import (
-	"context"
-	"fmt"
 	"time"
-
-	"github.com/buildkite/go-buildkite/v4"
-	"github.com/cenkalti/backoff/v4"
 )
 
 // JobState represents the possible states of a Buildkite job
@@ -68,67 +63,6 @@ var terminalStates = map[JobState]bool{
 // IsTerminalState returns true if the given job state is terminal
 func IsTerminalState(state JobState) bool {
 	return terminalStates[state]
-}
-
-// GetJobStatus retrieves the current status of a Buildkite job with retry logic
-func GetJobStatus(client *buildkite.Client, ctx context.Context, org, pipeline, build, jobID string) (*JobStatus, error) {
-	var buildInfo buildkite.Build
-	var err error
-
-	// Configure backoff for retries: max 3 retries, exponential backoff starting at 1s
-	bo := backoff.NewExponentialBackOff()
-	bo.InitialInterval = 1 * time.Second
-	bo.MaxElapsedTime = 30 * time.Second // Max total time to spend retrying
-	bo.MaxInterval = 10 * time.Second    // Max interval between retries
-
-	operation := func() error {
-		buildInfo, _, err = client.Builds.Get(ctx, org, pipeline, build, nil)
-		if err != nil {
-			return fmt.Errorf("failed to get build info: %w", err)
-		}
-		return nil
-	}
-
-	if err := backoff.Retry(operation, bo); err != nil {
-		return nil, fmt.Errorf("failed to get build info after retries: %w", err)
-	}
-
-	// buildInfo is a struct, so no need to check for nil
-
-	// Find the specific job in the build
-	var job buildkite.Job
-	var jobFound bool
-	for _, j := range buildInfo.Jobs {
-		if j.ID == jobID {
-			job = j
-			jobFound = true
-			break
-		}
-	}
-
-	if !jobFound {
-		return nil, fmt.Errorf("job not found: %s", jobID)
-	}
-
-	// Convert buildkite job to our JobStatus
-	state := JobState(job.State)
-	status := &JobStatus{
-		ID:         job.ID,
-		State:      state,
-		IsTerminal: IsTerminalState(state),
-		WebURL:     job.WebURL,
-	}
-
-	if job.ExitStatus != nil {
-		status.ExitStatus = job.ExitStatus
-	}
-
-	if job.FinishedAt != nil {
-		finishedAt := job.FinishedAt.Time
-		status.FinishedAt = &finishedAt
-	}
-
-	return status, nil
 }
 
 // ShouldRefreshCache determines if a cached entry should be refreshed based on job status and TTL


### PR DESCRIPTION
Also simplified the job status retrieval as underlying library has retry.